### PR TITLE
fix: client version property

### DIFF
--- a/ceresdb-protocol/src/main/resources/client_version.properties
+++ b/ceresdb-protocol/src/main/resources/client_version.properties
@@ -1,1 +1,1 @@
-client.version=1.0.1.RC2
+client.version=0.1.0


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change

The `client_version.properties` file records the client version, which is used in the [`display`](https://github.com/CeresDB/ceresdb-java-client/blob/main/ceresdb-protocol/src/main/java/com/ceresdb/CeresDBxClient.java#L232) output at runtime, and it should be consistent with the latest version of the current client.
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Upgrade the version in `client_version.properties` file.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
