### PR TITLE
chore: make version more maintainable and change it to 0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,6 @@
 # Log file
 *.log
 
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
 # Package Files #
 *.jar
 *.war
@@ -30,6 +24,8 @@ target
 .classpath
 .project
 .settings
+**/.flattened-pom.xml
+**/.flattened-pom.xml.bak
 
 # IDEA files
 *.iml

--- a/ceresdb-all/pom.xml
+++ b/ceresdb-all/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ceresdb-client</artifactId>
         <groupId>io.ceresdb</groupId>
-        <version>0.1.0-RC</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ceresdb-all</artifactId>

--- a/ceresdb-common/pom.xml
+++ b/ceresdb-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ceresdb-client</artifactId>
         <groupId>io.ceresdb</groupId>
-        <version>0.1.0-RC</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ceresdb-common</artifactId>

--- a/ceresdb-example/pom.xml
+++ b/ceresdb-example/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ceresdb-client</artifactId>
         <groupId>io.ceresdb</groupId>
-        <version>0.1.0-RC</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ceresdb-example</artifactId>

--- a/ceresdb-grpc/pom.xml
+++ b/ceresdb-grpc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ceresdb-client</artifactId>
         <groupId>io.ceresdb</groupId>
-        <version>0.1.0-RC</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ceresdb-grpc</artifactId>

--- a/ceresdb-http/pom.xml
+++ b/ceresdb-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ceresdb-client</artifactId>
         <groupId>io.ceresdb</groupId>
-        <version>0.1.0-RC</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ceresdb-http</artifactId>

--- a/ceresdb-protocol/pom.xml
+++ b/ceresdb-protocol/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ceresdb-client</artifactId>
         <groupId>io.ceresdb</groupId>
-        <version>0.1.0-RC</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ceresdb-protocol</artifactId>

--- a/ceresdb-rpc/pom.xml
+++ b/ceresdb-rpc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ceresdb-client</artifactId>
         <groupId>io.ceresdb</groupId>
-        <version>0.1.0-RC</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ceresdb-rpc</artifactId>

--- a/ceresdb-sql-javacc/pom.xml
+++ b/ceresdb-sql-javacc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ceresdb-client</artifactId>
         <groupId>io.ceresdb</groupId>
-        <version>0.1.0-RC</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ceresdb-sql-javacc</artifactId>

--- a/ceresdb-sql/pom.xml
+++ b/ceresdb-sql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>ceresdb-client</artifactId>
         <groupId>io.ceresdb</groupId>
-        <version>0.1.0-RC</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ceresdb-sql</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     </distributionManagement>
 
     <properties>
-
         <arvo.version>1.10.2</arvo.version>
         <gson.version>2.8.9</gson.version>
         <io.grpc.version>1.23.0</io.grpc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 
     <groupId>io.ceresdb</groupId>
     <artifactId>ceresdb-client</artifactId>
-    <version>0.1.0-RC</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <name>ceresdb-client</name>
-    <description>CeresDBClient is a high-performance Java client for CeresDB. CeresDB is a high-performance, distributed, schema-less, cloud native time-series database that can handle both time-series and analytics workloads.</description>
-    <url>https://github.com/CeresDB/ceresdb-client-java</url>
+    <description>Official Java client implementation for CeresDB.</description>
+    <url>https://github.com/CeresDB</url>
 
     <licenses>
         <license>
@@ -21,12 +21,8 @@
 
     <developers>
         <developer>
-            <name>zuliang.wzl</name>
-            <email>zuliangwanghust@gmail.com</email>
-        </developer>
-        <developer>
-            <name>weirong.cwr</name>
-            <email>weirong.cwr@gmail.com</email>
+            <name>ceresdb team</name>
+            <email>ceresdbservice@gmail.com</email>
         </developer>
     </developers>
 
@@ -60,6 +56,7 @@
     </distributionManagement>
 
     <properties>
+
         <arvo.version>1.10.2</arvo.version>
         <gson.version>2.8.9</gson.version>
         <io.grpc.version>1.23.0</io.grpc.version>
@@ -78,6 +75,8 @@
         <okio.version>2.8.0</okio.version>
         <project.encoding>UTF-8</project.encoding>
         <protobuf.version>3.21.7</protobuf.version>
+        <!-- according to https://maven.apache.org/maven-ci-friendly.html -->
+        <revision>0.1.0</revision>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 
@@ -455,6 +454,5 @@
             </plugin>
         </plugins>
     </build>
-
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.ceresdb</groupId>
@@ -451,6 +452,31 @@
                     <!-- ignore javadoc check-->
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
# Which issue does this PR close?

No, it is just the chore before release.

# Rationale for this change
The version field is scattered everywhere in the repo. The parent `pom.xml` and its children have their own version, however, in almost every case, they should be identical. Modifying all fields is tedious and error-prone work.

# What changes are included in this PR?
* We should use one variable to maintain versions. According to a document from `Apache Maven`, this is easy.
* Reference: https://maven.apache.org/maven-ci-friendly.html

# Are there any user-facing changes?
Real users are not influenced. Developers of this project should take care of this PR. If you want to change the version field, just modify the property `revision` in parent pom, rather than modify all pom files. It was not convenient to maintain the version field before. Developers would forget to alter the version field in child pom.

# How does this change test
Pass the existing CI.
