### PR TITLE
refactor: auto retrieve version from pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ CeresDB is a high-performance, distributed, schema-less, cloud native time-serie
 <dependency>
   <groupId>io.ceresdb</groupId>
   <artifactId>ceresdb-all</artifactId>
-  <version>0.1.0-RC</version>
+  <version>0.1.0</version>
 </dependency>
 ```
 

--- a/ceresdb-protocol/src/main/resources/client_version.properties
+++ b/ceresdb-protocol/src/main/resources/client_version.properties
@@ -1,1 +1,1 @@
-client.version=0.1.0
+client.version=${revision}

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <proto-internal.version>0.1.0</proto-internal.version>
         <protobuf.version>3.21.7</protobuf.version>
         <!-- according to https://maven.apache.org/maven-ci-friendly.html -->
-        <revision>0.1.0</revision>
+        <revision>0.2.0-alpha</revision>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>
 
@@ -484,6 +484,12 @@
                 </executions>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
 </project>


### PR DESCRIPTION
# Which issue does this PR close?

No, this PR refactor some code.

# Rationale for this change
 
The version in all `pom.xml` has been maintained by property `revision` after PR #35. However, there still exists an independently maintained version field in `./ceresdb-protocol/src/main/resources/client_version.properties`. This PR fixes it with functionality provided by maven (resource filtering).

# What changes are included in this PR?

parent pom and ./ceresdb-protocol/src/main/resources/client_version.properties.

# Are there any user-facing changes?

No.

# How does this change test

Pass the existing CI.