### PR TITLE
feat: add columns API in Row

### DIFF
--- a/ceresdb-example/src/test/java/io/ceresdb/CeresDBTest.java
+++ b/ceresdb-example/src/test/java/io/ceresdb/CeresDBTest.java
@@ -162,22 +162,22 @@ public class CeresDBTest {
                     "Data: ts={}, tString={}, tInt64={}, fString={}, fBool={}, fDouble={}, fFloat={}, fInt64={}, fInt32={}, fInt16={},"
                      + //
             "fInt8={}, fUint64={}, fUint32={}, fUint16={}, fUint8={}, fTimestamp={}, fVarbinary={}", //
-                    row.getColumnValue("ts").getTimestamp(), //
-                    row.getColumnValue("tString").getString(), //
-                    row.getColumnValue("tInt64").getInt64(), //
-                    row.getColumnValue("fString").getString(), //
-                    row.getColumnValue("fBool").getBoolean(), //
-                    row.getColumnValue("fDouble").getDouble(), //
-                    row.getColumnValue("fFloat").getFloat(), //
-                    row.getColumnValue("fInt64").getInt64(), //
-                    row.getColumnValue("fInt32").getInt32(), //
-                    row.getColumnValue("fInt16").getInt16(), //
-                    row.getColumnValue("fInt8").getInt8(), //
-                    row.getColumnValue("fUint64").getUInt64(), //
-                    row.getColumnValue("fUint32").getUInt32(), //
-                    row.getColumnValue("fUint16").getUInt16(), //
-                    row.getColumnValue("fUint8").getUInt8(), //
-                    row.getColumnValue("fTimestamp").getTimestamp() //
+                    row.getColumn("ts").value().getTimestamp(), //
+                    row.getColumn("tString").value().getString(), //
+                    row.getColumn("tInt64").value().getInt64(), //
+                    row.getColumn("fString").value().getString(), //
+                    row.getColumn("fBool").value().getBoolean(), //
+                    row.getColumn("fDouble").value().getDouble(), //
+                    row.getColumn("fFloat").value().getFloat(), //
+                    row.getColumn("fInt64").value().getInt64(), //
+                    row.getColumn("fInt32").value().getInt32(), //
+                    row.getColumn("fInt16").value().getInt16(), //
+                    row.getColumn("fInt8").value().getInt8(), //
+                    row.getColumn("fUint64").value().getUInt64(), //
+                    row.getColumn("fUint32").value().getUInt32(), //
+                    row.getColumn("fUint16").value().getUInt16(), //
+                    row.getColumn("fUint8").value().getUInt8(), //
+                    row.getColumn("fTimestamp").value().getTimestamp() //
             //row.getColumnValue("fVarbinary").getVarbinary())
             );
         });
@@ -303,7 +303,7 @@ public class CeresDBTest {
 
         int i = 0;
         while (it.hasNext()) {
-            LOG.info("The {} row, timestamp={}", ++i, it.next().getColumnValue("ts"));
+            LOG.info("The {} row, timestamp={}", ++i, it.next().getColumn("ts"));
         }
 
         Assert.assertEquals(1000, i);

--- a/ceresdb-example/src/test/java/io/ceresdb/CeresDBTest.java
+++ b/ceresdb-example/src/test/java/io/ceresdb/CeresDBTest.java
@@ -162,22 +162,22 @@ public class CeresDBTest {
                     "Data: ts={}, tString={}, tInt64={}, fString={}, fBool={}, fDouble={}, fFloat={}, fInt64={}, fInt32={}, fInt16={},"
                      + //
             "fInt8={}, fUint64={}, fUint32={}, fUint16={}, fUint8={}, fTimestamp={}, fVarbinary={}", //
-                    row.getColumn("ts").value().getTimestamp(), //
-                    row.getColumn("tString").value().getString(), //
-                    row.getColumn("tInt64").value().getInt64(), //
-                    row.getColumn("fString").value().getString(), //
-                    row.getColumn("fBool").value().getBoolean(), //
-                    row.getColumn("fDouble").value().getDouble(), //
-                    row.getColumn("fFloat").value().getFloat(), //
-                    row.getColumn("fInt64").value().getInt64(), //
-                    row.getColumn("fInt32").value().getInt32(), //
-                    row.getColumn("fInt16").value().getInt16(), //
-                    row.getColumn("fInt8").value().getInt8(), //
-                    row.getColumn("fUint64").value().getUInt64(), //
-                    row.getColumn("fUint32").value().getUInt32(), //
-                    row.getColumn("fUint16").value().getUInt16(), //
-                    row.getColumn("fUint8").value().getUInt8(), //
-                    row.getColumn("fTimestamp").value().getTimestamp() //
+                    row.getColumn("ts").getValue().getTimestamp(), //
+                    row.getColumn("tString").getValue().getString(), //
+                    row.getColumn("tInt64").getValue().getInt64(), //
+                    row.getColumn("fString").getValue().getString(), //
+                    row.getColumn("fBool").getValue().getBoolean(), //
+                    row.getColumn("fDouble").getValue().getDouble(), //
+                    row.getColumn("fFloat").getValue().getFloat(), //
+                    row.getColumn("fInt64").getValue().getInt64(), //
+                    row.getColumn("fInt32").getValue().getInt32(), //
+                    row.getColumn("fInt16").getValue().getInt16(), //
+                    row.getColumn("fInt8").getValue().getInt8(), //
+                    row.getColumn("fUint64").getValue().getUInt64(), //
+                    row.getColumn("fUint32").getValue().getUInt32(), //
+                    row.getColumn("fUint16").getValue().getUInt16(), //
+                    row.getColumn("fUint8").getValue().getUInt8(), //
+                    row.getColumn("fTimestamp").getValue().getTimestamp() //
             //row.getColumnValue("fVarbinary").getVarbinary())
             );
         });

--- a/ceresdb-example/src/test/java/io/ceresdb/ReadmeTest.java
+++ b/ceresdb-example/src/test/java/io/ceresdb/ReadmeTest.java
@@ -101,11 +101,11 @@ public class ReadmeTest {
 
         // get rows as list
         final List<Row> rows = queryOk.getRowList();
-        Assert.assertEquals(timestamp, rows.get(0).getColumn("ts").value().getTimestamp());
-        Assert.assertEquals("Singapore", rows.get(0).getColumn("city").value().getString());
-        Assert.assertEquals("10.0.0.1", rows.get(0).getColumn("ip").value().getString());
-        Assert.assertEquals(0.23, rows.get(0).getColumn("cpu").value().getDouble(), 0.0000001);
-        Assert.assertEquals(0.55, rows.get(0).getColumn("mem").value().getDouble(), 0.0000001);
+        Assert.assertEquals(timestamp, rows.get(0).getColumn("ts").getValue().getTimestamp());
+        Assert.assertEquals("Singapore", rows.get(0).getColumn("city").getValue().getString());
+        Assert.assertEquals("10.0.0.1", rows.get(0).getColumn("ip").getValue().getString());
+        Assert.assertEquals(0.23, rows.get(0).getColumn("cpu").getValue().getDouble(), 0.0000001);
+        Assert.assertEquals(0.55, rows.get(0).getColumn("mem").getValue().getDouble(), 0.0000001);
 
         // get rows as stream
         final Stream<Row> rowStream = queryOk.stream();

--- a/ceresdb-example/src/test/java/io/ceresdb/ReadmeTest.java
+++ b/ceresdb-example/src/test/java/io/ceresdb/ReadmeTest.java
@@ -101,11 +101,11 @@ public class ReadmeTest {
 
         // get rows as list
         final List<Row> rows = queryOk.getRowList();
-        Assert.assertEquals(timestamp, rows.get(0).getColumnValue("ts").getTimestamp());
-        Assert.assertEquals("Singapore", rows.get(0).getColumnValue("city").getString());
-        Assert.assertEquals("10.0.0.1", rows.get(0).getColumnValue("ip").getString());
-        Assert.assertEquals(0.23, rows.get(0).getColumnValue("cpu").getDouble(), 0.0000001);
-        Assert.assertEquals(0.55, rows.get(0).getColumnValue("mem").getDouble(), 0.0000001);
+        Assert.assertEquals(timestamp, rows.get(0).getColumn("ts").value().getTimestamp());
+        Assert.assertEquals("Singapore", rows.get(0).getColumn("city").value().getString());
+        Assert.assertEquals("10.0.0.1", rows.get(0).getColumn("ip").value().getString());
+        Assert.assertEquals(0.23, rows.get(0).getColumn("cpu").value().getDouble(), 0.0000001);
+        Assert.assertEquals(0.55, rows.get(0).getColumn("mem").value().getDouble(), 0.0000001);
 
         // get rows as stream
         final Stream<Row> rowStream = queryOk.stream();

--- a/ceresdb-protocol/src/main/java/io/ceresdb/WriteClient.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/WriteClient.java
@@ -456,7 +456,7 @@ public class WriteClient implements Write, Lifecycle<WriteOptions>, Display {
             tagDict.toOrdered().forEach((tagK) -> {
                 Value tagV = point.getTags().get(tagK);
                 if (!Value.isNull(tagV)) {
-                    seriesKeyBuffer.append(tagV.getValue().toString());
+                    seriesKeyBuffer.append(tagV.getAnyValue().toString());
                 }
             });
             Storage.WriteSeriesEntry.Builder seriesEntryBuilder = tp3.getSeriesBuilders()

--- a/ceresdb-protocol/src/main/java/io/ceresdb/WriteClient.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/WriteClient.java
@@ -456,7 +456,7 @@ public class WriteClient implements Write, Lifecycle<WriteOptions>, Display {
             tagDict.toOrdered().forEach((tagK) -> {
                 Value tagV = point.getTags().get(tagK);
                 if (!Value.isNull(tagV)) {
-                    seriesKeyBuffer.append(tagV.getAnyValue().toString());
+                    seriesKeyBuffer.append(tagV.getObject().toString());
                 }
             });
             Storage.WriteSeriesEntry.Builder seriesEntryBuilder = tp3.getSeriesBuilders()

--- a/ceresdb-protocol/src/main/java/io/ceresdb/models/Row.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/models/Row.java
@@ -76,11 +76,11 @@ public class Row {
         private String name;
         private Value  value;
 
-        public String name() {
+        public String getName() {
             return name;
         }
 
-        public Value value() {
+        public Value getValue() {
             return value;
         }
 

--- a/ceresdb-protocol/src/main/java/io/ceresdb/models/Row.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/models/Row.java
@@ -21,7 +21,7 @@ public class Row {
 
     public Column getColumn(String name) {
         int columnIdx = getColumnIdx(name);
-        if (columnIdx > 0) {
+        if (columnIdx > -1) {
             return Column.of(name, values[columnIdx]);
         }
         return null;

--- a/ceresdb-protocol/src/main/java/io/ceresdb/models/Row.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/models/Row.java
@@ -3,39 +3,114 @@
  */
 package io.ceresdb.models;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class Row {
-    private Map<String, Value> values;
+    protected String[] fields;
+    protected Value[]  values;
 
-    public Row() {
-        this.values = new HashMap<>();
+    protected Row() {
     }
 
-    public Value getColumnValue(String column) {
-        return this.values.get(column);
+    public boolean hasColumn(String name) {
+        return getColumnIdx(name) > -1;
     }
 
-    public void setColumnValue(String column, Value value) {
-        this.values.put(column, value);
+    public Column getColumn(String name) {
+        int columnIdx = getColumnIdx(name);
+        if (columnIdx > 0) {
+            return Column.of(name, values[columnIdx]);
+        }
+        return null;
+    }
+
+    public List<Column> getColumns() {
+        if (fields == null) {
+            return Collections.emptyList();
+        }
+        List<Column> columns = new ArrayList<>(getColumnCount());
+        for (int idx = 0; idx < fields.length; idx++) {
+            columns.add(Column.of(fields[idx], values[idx]));
+        }
+        return columns;
     }
 
     public int getColumnCount() {
-        if (this.values == null) {
+        if (fields == null) {
             return 0;
         }
-        return this.values.size();
+        return fields.length;
+    }
+
+    private int getColumnIdx(String name) {
+        if (fields == null) {
+            return -1;
+        }
+        for (int idx = 0; idx < fields.length; idx++) {
+            if (fields[idx].equals(name)) {
+                return idx;
+            }
+        }
+        return -1;
     }
 
     @Override
     public String toString() {
-        if (this.values == null || this.values.isEmpty()) {
+        if (this.fields == null || this.fields.length == 0) {
             return "[Empty Row]";
         }
 
-        return this.values.entrySet().stream().map(entry -> entry.getKey() + ":" + entry.getValue().toString())
+        return getColumns().stream().map(column -> column.name + ":" + column.value.toString())
                 .collect(Collectors.joining("|"));
+    }
+
+    public static class Column {
+        public Column(String name, Value value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        private String name;
+        private Value  value;
+
+        public String name() {
+            return name;
+        }
+
+        public Value value() {
+            return value;
+        }
+
+        public static Column of(String name, Value value) {
+            return new Column(name, value);
+        }
+    }
+
+    public static RowBuilder newRowBuilder(int size) {
+        return new RowBuilder(size);
+    }
+
+    public static class RowBuilder {
+        private Row row;
+
+        public RowBuilder(int size) {
+            this.row = new Row();
+            this.row.values = new Value[size];
+        }
+
+        public void setFields(String[] fields) {
+            this.row.fields = fields;
+        }
+
+        public void setValue(int colIdx, Value value) {
+            this.row.values[colIdx] = value;
+        }
+
+        public Row build() {
+            return this.row;
+        }
     }
 }

--- a/ceresdb-protocol/src/main/java/io/ceresdb/models/Value.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/models/Value.java
@@ -72,7 +72,7 @@ public class Value {
         return type;
     }
 
-    public Object getAnyValue() {
+    public Object getObject() {
         return value;
     }
 

--- a/ceresdb-protocol/src/main/java/io/ceresdb/models/Value.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/models/Value.java
@@ -72,7 +72,7 @@ public class Value {
         return type;
     }
 
-    public Object getValue() {
+    public Object getAnyValue() {
         return value;
     }
 

--- a/ceresdb-protocol/src/main/java/io/ceresdb/util/Utils.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/util/Utils.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -468,20 +469,23 @@ public final class Utils {
     }
 
     private static List<Row> parseArrowRecord(Schema schema, VectorSchemaRoot root) {
-        List<Row> rows = Stream.generate(Row::new).limit(root.getRowCount()).collect(Collectors.toList());
+        List<Row.RowBuilder> builders = Collections.nCopies(root.getRowCount(),
+                Row.newRowBuilder(schema.getFields().size()));
 
+        String[] fields = new String[schema.getFields().size()];
         for (int fieldIdx = 0; fieldIdx < schema.getFields().size(); fieldIdx++) {
             Field field = schema.getFields().get(fieldIdx);
-            FieldVector vector = root.getVector(fieldIdx);
+            fields[fieldIdx] = field.getName();
 
+            FieldVector vector = root.getVector(fieldIdx);
             switch (Types.getMinorTypeForArrowType(field.getType())) {
                 case VARCHAR:
                     VarCharVector varCharVector = (VarCharVector) vector;
                     for (int rowIdx = 0; rowIdx < varCharVector.getValueCount(); rowIdx++) {
                         if (varCharVector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withStringOrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withStringOrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(),
+                            builders.get(rowIdx).setValue(fieldIdx,
                                     Value.withString(new String(varCharVector.get(rowIdx))));
                         }
                     }
@@ -490,10 +494,9 @@ public final class Utils {
                     BitVector bitVector = (BitVector) vector;
                     for (int rowIdx = 0; rowIdx < bitVector.getValueCount(); rowIdx++) {
                         if (bitVector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withBooleanOrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withBooleanOrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(),
-                                    Value.withBoolean(bitVector.get(rowIdx) > 0));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withBoolean(bitVector.get(rowIdx) > 0));
                         }
                     }
                     break;
@@ -501,10 +504,9 @@ public final class Utils {
                     Float8Vector float8Vector = (Float8Vector) vector;
                     for (int rowIdx = 0; rowIdx < float8Vector.getValueCount(); rowIdx++) {
                         if (float8Vector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withDoubleOrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withDoubleOrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(),
-                                    Value.withDouble(float8Vector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withDouble(float8Vector.get(rowIdx)));
                         }
                     }
                     break;
@@ -512,9 +514,9 @@ public final class Utils {
                     Float4Vector float4Vector = (Float4Vector) vector;
                     for (int rowIdx = 0; rowIdx < float4Vector.getValueCount(); rowIdx++) {
                         if (float4Vector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withFloatOrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withFloatOrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withFloat(float4Vector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withFloat(float4Vector.get(rowIdx)));
                         }
                     }
                     break;
@@ -522,9 +524,9 @@ public final class Utils {
                     BigIntVector bigIntVector = (BigIntVector) vector;
                     for (int rowIdx = 0; rowIdx < bigIntVector.getValueCount(); rowIdx++) {
                         if (bigIntVector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withInt64OrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withInt64OrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withInt64(bigIntVector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withInt64(bigIntVector.get(rowIdx)));
                         }
                     }
                     break;
@@ -532,9 +534,9 @@ public final class Utils {
                     IntVector intVector = (IntVector) vector;
                     for (int rowIdx = 0; rowIdx < intVector.getValueCount(); rowIdx++) {
                         if (intVector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withInt32OrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withInt32OrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withInt32(intVector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withInt32(intVector.get(rowIdx)));
                         }
                     }
                     break;
@@ -542,10 +544,9 @@ public final class Utils {
                     SmallIntVector smallIntVector = (SmallIntVector) vector;
                     for (int rowIdx = 0; rowIdx < smallIntVector.getValueCount(); rowIdx++) {
                         if (smallIntVector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withInt16OrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withInt16OrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(),
-                                    Value.withInt16(smallIntVector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withInt16(smallIntVector.get(rowIdx)));
                         }
                     }
                     break;
@@ -553,9 +554,9 @@ public final class Utils {
                     TinyIntVector tinyIntVector = (TinyIntVector) vector;
                     for (int rowIdx = 0; rowIdx < tinyIntVector.getValueCount(); rowIdx++) {
                         if (tinyIntVector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withInt8OrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withInt8OrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withInt8(tinyIntVector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withInt8(tinyIntVector.get(rowIdx)));
                         }
                     }
                     break;
@@ -563,9 +564,9 @@ public final class Utils {
                     UInt8Vector uInt8Vector = (UInt8Vector) vector;
                     for (int rowIdx = 0; rowIdx < uInt8Vector.getValueCount(); rowIdx++) {
                         if (uInt8Vector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withUInt64OrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withUInt64OrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withUInt64(uInt8Vector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withUInt64(uInt8Vector.get(rowIdx)));
                         }
                     }
                     break;
@@ -573,9 +574,9 @@ public final class Utils {
                     UInt4Vector uInt4Vector = (UInt4Vector) vector;
                     for (int rowIdx = 0; rowIdx < uInt4Vector.getValueCount(); rowIdx++) {
                         if (uInt4Vector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withUInt32OrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withUInt32OrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withUInt32(uInt4Vector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withUInt32(uInt4Vector.get(rowIdx)));
                         }
                     }
                     break;
@@ -583,9 +584,9 @@ public final class Utils {
                     UInt2Vector uInt2Vector = (UInt2Vector) vector;
                     for (int rowIdx = 0; rowIdx < uInt2Vector.getValueCount(); rowIdx++) {
                         if (uInt2Vector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withUInt16OrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withUInt16OrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withUInt16(uInt2Vector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withUInt16(uInt2Vector.get(rowIdx)));
                         }
                     }
                     break;
@@ -593,9 +594,9 @@ public final class Utils {
                     UInt1Vector uInt1Vector = (UInt1Vector) vector;
                     for (int rowIdx = 0; rowIdx < uInt1Vector.getValueCount(); rowIdx++) {
                         if (uInt1Vector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withUInt8OrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withUInt8OrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withUInt8(uInt1Vector.get(rowIdx)));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withUInt8(uInt1Vector.get(rowIdx)));
                         }
                     }
                     break;
@@ -603,9 +604,9 @@ public final class Utils {
                     TimeStampMilliVector timeStampMilliVector = (TimeStampMilliVector) vector;
                     for (int rowIdx = 0; rowIdx < timeStampMilliVector.getValueCount(); rowIdx++) {
                         if (timeStampMilliVector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withTimestampOrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withTimestampOrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(),
+                            builders.get(rowIdx).setValue(fieldIdx,
                                     Value.withTimestamp(timeStampMilliVector.get(rowIdx)));
                         }
                     }
@@ -614,9 +615,9 @@ public final class Utils {
                     VarBinaryVector varBinaryVector = (VarBinaryVector) vector;
                     for (int rowIdx = 0; rowIdx < varBinaryVector.getValueCount(); rowIdx++) {
                         if (varBinaryVector.isNull(rowIdx)) {
-                            rows.get(rowIdx).setColumnValue(field.getName(), Value.withVarbinaryOrNull(null));
+                            builders.get(rowIdx).setValue(fieldIdx, Value.withVarbinaryOrNull(null));
                         } else {
-                            rows.get(rowIdx).setColumnValue(field.getName(),
+                            builders.get(rowIdx).setValue(fieldIdx,
                                     Value.withVarbinaryOrNull(varBinaryVector.get(rowIdx)));
                         }
                     }
@@ -626,7 +627,9 @@ public final class Utils {
 
             }
         }
-        return rows;
+
+        builders.stream().forEach(builder -> builder.setFields(fields));
+        return builders.stream().map(builder -> builder.build()).collect(Collectors.toList());
     }
 
     private Utils() {

--- a/ceresdb-protocol/src/main/java/io/ceresdb/util/Utils.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/util/Utils.java
@@ -7,7 +7,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -22,7 +21,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import io.ceresdb.Route;
 import io.ceresdb.common.Display;

--- a/ceresdb-protocol/src/test/java/io/ceresdb/QueryClientTest.java
+++ b/ceresdb-protocol/src/test/java/io/ceresdb/QueryClientTest.java
@@ -209,20 +209,20 @@ public class QueryClientTest {
     private void checkFullTypeRow(final Row row) {
         Assert.assertEquals(14, row.getColumnCount());
 
-        Assert.assertEquals("test", row.getColumnValue("fString").getString());
-        Assert.assertEquals(Boolean.TRUE, row.getColumnValue("fBool").getBoolean());
-        Assert.assertEquals(0.64, row.getColumnValue("fDouble").getDouble(), 0.000001);
-        Assert.assertEquals(0.32f, row.getColumnValue("fFloat").getFloat(), 0.000001);
-        Assert.assertEquals(-64, row.getColumnValue("fInt64").getInt64());
-        Assert.assertEquals(-32, row.getColumnValue("fInt32").getInt32());
-        Assert.assertEquals(-16, row.getColumnValue("fInt16").getInt16());
-        Assert.assertEquals(-8, row.getColumnValue("fInt8").getInt8());
-        Assert.assertEquals(64, row.getColumnValue("fUint64").getUInt64());
-        Assert.assertEquals(32, row.getColumnValue("fUint32").getUInt32());
-        Assert.assertEquals(16, row.getColumnValue("fUint16").getUInt16());
-        Assert.assertEquals(8, row.getColumnValue("fUint8").getUInt8());
-        Assert.assertEquals(1675345488158L, row.getColumnValue("fTimestamp").getTimestamp());
-        Assert.assertArrayEquals(new byte[] { 1, 2, 3 }, row.getColumnValue("fVarbinary").getVarbinary());
+        Assert.assertEquals("test", row.getColumn("fString").value().getString());
+        Assert.assertEquals(Boolean.TRUE, row.getColumn("fBool").value().getBoolean());
+        Assert.assertEquals(0.64, row.getColumn("fDouble").value().getDouble(), 0.000001);
+        Assert.assertEquals(0.32f, row.getColumn("fFloat").value().getFloat(), 0.000001);
+        Assert.assertEquals(-64, row.getColumn("fInt64").value().getInt64());
+        Assert.assertEquals(-32, row.getColumn("fInt32").value().getInt32());
+        Assert.assertEquals(-16, row.getColumn("fInt16").value().getInt16());
+        Assert.assertEquals(-8, row.getColumn("fInt8").value().getInt8());
+        Assert.assertEquals(64, row.getColumn("fUint64").value().getUInt64());
+        Assert.assertEquals(32, row.getColumn("fUint32").value().getUInt32());
+        Assert.assertEquals(16, row.getColumn("fUint16").value().getUInt16());
+        Assert.assertEquals(8, row.getColumn("fUint8").value().getUInt8());
+        Assert.assertEquals(1675345488158L, row.getColumn("fTimestamp").value().getTimestamp());
+        Assert.assertArrayEquals(new byte[] { 1, 2, 3 }, row.getColumn("fVarbinary").value().getVarbinary());
     }
 
     @Test
@@ -249,8 +249,8 @@ public class QueryClientTest {
         final SqlQueryOk queryOk = r.getOk();
 
         Row row = queryOk.stream().findFirst().get();
-        Assert.assertEquals("tvtest", row.getColumnValue("t1").getString());
-        Assert.assertTrue(row.getColumnValue("f1").isNull());
+        Assert.assertEquals("tvtest", row.getColumn("t1").value().getString());
+        Assert.assertTrue(row.getColumn("f1").value().isNull());
     }
 
     private Result<SqlQueryOk, Err> queryByArrow() throws IOException, ExecutionException, InterruptedException {

--- a/ceresdb-protocol/src/test/java/io/ceresdb/QueryClientTest.java
+++ b/ceresdb-protocol/src/test/java/io/ceresdb/QueryClientTest.java
@@ -209,20 +209,20 @@ public class QueryClientTest {
     private void checkFullTypeRow(final Row row) {
         Assert.assertEquals(14, row.getColumnCount());
 
-        Assert.assertEquals("test", row.getColumn("fString").value().getString());
-        Assert.assertEquals(Boolean.TRUE, row.getColumn("fBool").value().getBoolean());
-        Assert.assertEquals(0.64, row.getColumn("fDouble").value().getDouble(), 0.000001);
-        Assert.assertEquals(0.32f, row.getColumn("fFloat").value().getFloat(), 0.000001);
-        Assert.assertEquals(-64, row.getColumn("fInt64").value().getInt64());
-        Assert.assertEquals(-32, row.getColumn("fInt32").value().getInt32());
-        Assert.assertEquals(-16, row.getColumn("fInt16").value().getInt16());
-        Assert.assertEquals(-8, row.getColumn("fInt8").value().getInt8());
-        Assert.assertEquals(64, row.getColumn("fUint64").value().getUInt64());
-        Assert.assertEquals(32, row.getColumn("fUint32").value().getUInt32());
-        Assert.assertEquals(16, row.getColumn("fUint16").value().getUInt16());
-        Assert.assertEquals(8, row.getColumn("fUint8").value().getUInt8());
-        Assert.assertEquals(1675345488158L, row.getColumn("fTimestamp").value().getTimestamp());
-        Assert.assertArrayEquals(new byte[] { 1, 2, 3 }, row.getColumn("fVarbinary").value().getVarbinary());
+        Assert.assertEquals("test", row.getColumn("fString").getValue().getString());
+        Assert.assertEquals(Boolean.TRUE, row.getColumn("fBool").getValue().getBoolean());
+        Assert.assertEquals(0.64, row.getColumn("fDouble").getValue().getDouble(), 0.000001);
+        Assert.assertEquals(0.32f, row.getColumn("fFloat").getValue().getFloat(), 0.000001);
+        Assert.assertEquals(-64, row.getColumn("fInt64").getValue().getInt64());
+        Assert.assertEquals(-32, row.getColumn("fInt32").getValue().getInt32());
+        Assert.assertEquals(-16, row.getColumn("fInt16").getValue().getInt16());
+        Assert.assertEquals(-8, row.getColumn("fInt8").getValue().getInt8());
+        Assert.assertEquals(64, row.getColumn("fUint64").getValue().getUInt64());
+        Assert.assertEquals(32, row.getColumn("fUint32").getValue().getUInt32());
+        Assert.assertEquals(16, row.getColumn("fUint16").getValue().getUInt16());
+        Assert.assertEquals(8, row.getColumn("fUint8").getValue().getUInt8());
+        Assert.assertEquals(1675345488158L, row.getColumn("fTimestamp").getValue().getTimestamp());
+        Assert.assertArrayEquals(new byte[] { 1, 2, 3 }, row.getColumn("fVarbinary").getValue().getVarbinary());
     }
 
     @Test
@@ -249,8 +249,8 @@ public class QueryClientTest {
         final SqlQueryOk queryOk = r.getOk();
 
         Row row = queryOk.stream().findFirst().get();
-        Assert.assertEquals("tvtest", row.getColumn("t1").value().getString());
-        Assert.assertTrue(row.getColumn("f1").value().isNull());
+        Assert.assertEquals("tvtest", row.getColumn("t1").getValue().getString());
+        Assert.assertTrue(row.getColumn("f1").getValue().isNull());
     }
 
     private Result<SqlQueryOk, Err> queryByArrow() throws IOException, ExecutionException, InterruptedException {

--- a/ceresdb-protocol/src/test/java/io/ceresdb/QueryClientTest.java
+++ b/ceresdb-protocol/src/test/java/io/ceresdb/QueryClientTest.java
@@ -115,7 +115,7 @@ public class QueryClientTest {
         final Stream<String> strs = queryOk.map(Row::toString);
 
         Assert.assertEquals(
-                Collections.singletonList("f1:Value{type=Int32,value=123}|t1:Value{type=String,value=tvtest}"),
+                Collections.singletonList("t1:Value{type=String,value=tvtest}|f1:Value{type=Int32,value=123}"),
                 strs.collect(Collectors.toList()));
     }
 
@@ -150,7 +150,7 @@ public class QueryClientTest {
         final Stream<String> strs = queryOk.map(Row::toString);
 
         Assert.assertEquals(
-                Collections.singletonList("f1:Value{type=Int32,value=123}|t1:Value{type=String,value=tvtest}"),
+                Collections.singletonList("t1:Value{type=String,value=tvtest}|f1:Value{type=Int32,value=123}"),
                 strs.collect(Collectors.toList()));
     }
 

--- a/ceresdb-protocol/src/test/java/io/ceresdb/models/RowTest.java
+++ b/ceresdb-protocol/src/test/java/io/ceresdb/models/RowTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+ */
+package io.ceresdb.models;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RowTest {
+    @Test
+    public void RowBuilderTest() {
+        Row.RowBuilder builder = new Row.RowBuilder(5);
+
+        String[] fields = new String[] { "timestamp", "tagA", "tagB", "valueA", "valueB" };
+        builder.setValue(4, Value.withInt64(123));
+        builder.setValue(2, Value.withString("foo"));
+        builder.setValue(0, Value.withTimestamp(12345678L));
+        builder.setValue(1, Value.withString("bar"));
+        builder.setValue(3, Value.withString("haha"));
+        builder.setFields(fields);
+
+        Row row = builder.build();
+
+        Assert.assertEquals(row.getColumnCount(), 5);
+        Assert.assertTrue(row.hasColumn("tagA"));
+        Assert.assertFalse(row.hasColumn("notExist"));
+        Assert.assertEquals(row.getColumn("tagA").value().getString(), "bar");
+        Assert.assertNull(row.getColumn("notExist"));
+
+        List<Row.Column> columns = row.getColumns();
+        Assert.assertEquals(columns.size(), 5);
+        Assert.assertEquals(columns.get(1).value().getString(), "bar");
+        Assert.assertEquals(columns.get(4).value().getInt64(), 123);
+    }
+}

--- a/ceresdb-protocol/src/test/java/io/ceresdb/models/RowTest.java
+++ b/ceresdb-protocol/src/test/java/io/ceresdb/models/RowTest.java
@@ -26,12 +26,12 @@ public class RowTest {
         Assert.assertEquals(row.getColumnCount(), 5);
         Assert.assertTrue(row.hasColumn("tagA"));
         Assert.assertFalse(row.hasColumn("notExist"));
-        Assert.assertEquals(row.getColumn("tagA").value().getString(), "bar");
+        Assert.assertEquals(row.getColumn("tagA").getValue().getString(), "bar");
         Assert.assertNull(row.getColumn("notExist"));
 
         List<Row.Column> columns = row.getColumns();
         Assert.assertEquals(columns.size(), 5);
-        Assert.assertEquals(columns.get(1).value().getString(), "bar");
-        Assert.assertEquals(columns.get(4).value().getInt64(), 123);
+        Assert.assertEquals(columns.get(1).getValue().getString(), "bar");
+        Assert.assertEquals(columns.get(4).getValue().getInt64(), 123);
     }
 }

--- a/docs/read.md
+++ b/docs/read.md
@@ -87,7 +87,7 @@ CompletableFuture<Result<SqlQueryOk, Err>> sqlQuery(SqlQueryRequest req, Context
 - When processing the results returned by the query, the user can directly obtain `List<Row>`, or process it through stream.
 - Row is a collection of Value, which is a very simple data structure
 - Note: When Value gets the java primitive value, you need to pass in the type method that matches the table creation, otherwise an error will be reported
-- Example to use `Row`: `row.getColumnValue("cpu_util").getDouble()
+- Example to use `Row`: `row.getColumn("cpu_util").value().getDouble()
   `
 
 `Err`


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Add some api in row for iteration, used in scenarios where the user does not know the schema

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

- Add struct `Column`
- `Row` add api `getColumns()` to get total columns in one row

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

- `Row` getColumnValue(string) Value` is changed as `getColumn(string) Column`
- `Value` `Object Value()` is changed as `Object AnyValue()`

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
All unit test is paased