### PR TITLE
fix: remove fields empty check

### DIFF
--- a/ceresdb-protocol/src/main/java/io/ceresdb/models/Point.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/models/Point.java
@@ -81,7 +81,6 @@ public class Point {
 
         private static void check(final Point point) throws IllegalArgumentException {
             Requires.requireNonNull(point.fields, "Null.fields");
-            Requires.requireTrue(!point.fields.isEmpty(), "Empty.fields");
             Utils.checkKeywords(point.tags.keySet().stream().iterator());
             Utils.checkKeywords(point.fields.keySet().stream().iterator());
         }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
Sometime there is no fields in a table,  error occurs when data writing :  

```
java.lang.IllegalArgumentException: Empty.fields
        at io.shaded.ceresdb.common.util.Requires.requireTrue(Requires.java:72)
        at io.shaded.ceresdb.models.Point$PointBuilder.check(Point.java:84)
        at io.shaded.ceresdb.models.Point$PointBuilder.build(Point.java:78)
```

# What changes are included in this PR?

Remove  fields empty check.


# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
