### PR TITLE
fix: add default endpoint for partition table

### DIFF
--- a/ceresdb-protocol/src/main/java/io/ceresdb/RouterClient.java
+++ b/ceresdb-protocol/src/main/java/io/ceresdb/RouterClient.java
@@ -44,10 +44,9 @@ import com.codahale.metrics.Timer;
 
 /**
  * A route rpc client which implement RouteMode.Direct
- *
+ * <p>
  * cached the routing table information locally
  * and will refresh when the server returns an error code of INVALID_ROUTE
- *
  */
 public class RouterClient implements Lifecycle<RouterOptions>, Display, Iterable<Route> {
 
@@ -410,7 +409,11 @@ public class RouterClient implements Lifecycle<RouterOptions>, Display, Iterable
 
         private Route toRouteObj(final Storage.Route r) {
             final Storage.Endpoint ep = Requires.requireNonNull(r.getEndpoint(), "CeresDB.Endpoint");
-            return Route.of(r.getTable(), Endpoint.of(ep.getIp(), ep.getPort()));
+            if (r.getEndpoint().getIp().isEmpty()) {
+                return Route.of(r.getTable(), this.endpoint);
+            } else {
+                return Route.of(r.getTable(), Endpoint.of(ep.getIp(), ep.getPort()));
+            }
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #62 

# Rationale for this change
In the latest implementation, the route result of the partition table is empty, and we need to make it be queried normally.

# What changes are included in this PR?
* Add default endpoint for partition table

# Are there any user-facing changes?
None.

# How does this change test
Pass all unit tests.
