### PR TITLE
chore: update protected_tags in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,6 +41,7 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
+  protected_tags: []
 
 notifications:
   commits:      commits@horaedb.apache.org


### PR DESCRIPTION
## Rationale
Update protected_tags in `.asf.yaml`.

## Detailed Changes
Temporarily ignore tag protection in order to remove erroneous tags v2.0.0 .

## Test Plan
No need.